### PR TITLE
Ignore file attributes when syncing

### DIFF
--- a/scrapy_dotpersistence.py
+++ b/scrapy_dotpersistence.py
@@ -56,13 +56,13 @@ class DotScrapyPersistence(object):
         if not os.path.isdir(self._localpath):
             os.makedirs(self._localpath)
 
-        cmd = ['s3cmd', 'sync', self._s3path, self._localpath]
+        cmd = ['s3cmd', 'sync', '--no-preserve', self._s3path, self._localpath]
         self._call(cmd)
 
     def _store_data(self):
         # check for reason status here?
         logger.info('Syncing .scrapy directory to %s' % self._s3path)
-        cmd = ['s3cmd', 'sync', '--delete-removed',
+        cmd = ['s3cmd', 'sync', '--no-preserve', '--delete-removed',
                self._localpath, self._s3path]
         self._call(cmd)
 

--- a/tests/test_dotpersistence.py
+++ b/tests/test_dotpersistence.py
@@ -75,7 +75,7 @@ class DotScrapyPersisitenceTestCase(TestCase):
         self.assertEqual(self.instance._s3path, s3_path1)
         assert os.path.exists(self.instance._localpath)
         mocked_call.assert_called_with(
-            ['s3cmd', 'sync', s3_path1, '/tmp/.scrapy'])
+            ['s3cmd', 'sync', '--no-preserve', s3_path1, '/tmp/.scrapy'])
 
         # test other s3_path w/o bucket_folder
         mocked_call.reset()
@@ -84,14 +84,15 @@ class DotScrapyPersisitenceTestCase(TestCase):
         s3_path2 = 's3://test-bucket/123/dot-scrapy/testspider/'
         self.assertEqual(self.instance._s3path, s3_path2)
         mocked_call.assert_called_with(
-            ['s3cmd', 'sync', s3_path2, '/tmp/.scrapy'])
+            ['s3cmd', 'sync', '--no-preserve', s3_path2, '/tmp/.scrapy'])
 
     def test_store_data(self):
         mocked_call = mock.Mock()
         self.instance._call = mocked_call
         self.instance._store_data()
         mocked_call.assert_called_with(
-            ['s3cmd', 'sync', '--delete-removed', '/tmp/.scrapy',
+            ['s3cmd', 'sync', '--no-preserve',
+             '--delete-removed', '/tmp/.scrapy',
              's3://test-bucket/test-user/123/dot-scrapy/testspider/'])
 
     def test_call(self):


### PR DESCRIPTION
This patch allows to avoid some weird errors when a user doesn't have enough permissions to set the same uid/gid of a file from s3 (true at least for s3cmd==1.6).

Review, pls.
