### PR TITLE
Increate multipart chunk size when storing to S3

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.0
+current_version = 0.1.1
 commit = True
 tag = True
 tag_name = v{new_version}

--- a/scrapy_dotpersistence.py
+++ b/scrapy_dotpersistence.py
@@ -62,7 +62,9 @@ class DotScrapyPersistence(object):
     def _store_data(self):
         # check for reason status here?
         logger.info('Syncing .scrapy directory to %s' % self._s3path)
-        cmd = ['s3cmd', 'sync', '--no-preserve', '--delete-removed',
+        cmd = ['s3cmd', 'sync', '--no-preserve',
+               '--multipart-chunk-size-mb=5120',
+               '--delete-removed',
                self._localpath, self._s3path]
         self._call(cmd)
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='scrapy-dotpersistence',
-    version='0.1.0',
+    version='0.1.1',
     url='https://github.com/scrapy-plugins/scrapy-dotpersistence',
     description='Scrapy extension to sync `.scrapy` folder to an S3 bucket',
     long_description=open('README.rst').read(),

--- a/tests/test_dotpersistence.py
+++ b/tests/test_dotpersistence.py
@@ -92,6 +92,7 @@ class DotScrapyPersisitenceTestCase(TestCase):
         self.instance._store_data()
         mocked_call.assert_called_with(
             ['s3cmd', 'sync', '--no-preserve',
+             '--multipart-chunk-size-mb=5120',
              '--delete-removed', '/tmp/.scrapy',
              's3://test-bucket/test-user/123/dot-scrapy/testspider/'])
 


### PR DESCRIPTION
Currently S3cmd doesn't work well with multipart-uploaded files: it compares only its existence & size difference. But, for example, DeltaFetch  `bsddb` db logic allocates space in advance, so sometimes you can loose new data (don't update S3 data properly).

Proof https://github.com/s3tools/s3cmd/blob/v1.6.0/S3/FileLists.py#L506
Opened issue https://github.com/s3tools/s3cmd/issues/520

The PR increases multipart chunk size from 15MB to 5GB, that should be enough to avoid such issues until a necessary patch for S3cmd.
