### PR TITLE
Run extension outside scrapy cloud

### DIFF
--- a/scrapy_dotpersistence.py
+++ b/scrapy_dotpersistence.py
@@ -15,7 +15,7 @@ class DotScrapyPersistence(object):
         settings = crawler.settings
         enabled = (settings.getbool('DOTSCRAPY_ENABLED') or
                    settings.get('DOTSCRAPYPERSISTENCE_ENABLED'))
-        if not enabled or 'SCRAPY_JOB' not in os.environ:
+        if not enabled:
             raise NotConfigured
         bucket = settings.get('ADDONS_S3_BUCKET')
         return cls(crawler, bucket)
@@ -27,8 +27,8 @@ class DotScrapyPersistence(object):
             'ADDONS_AWS_SECRET_ACCESS_KEY')
         self._bucket = bucket
         self._bucket_folder = crawler.settings.get('ADDONS_AWS_USERNAME', '')
-        self._projectid = os.environ['SCRAPY_PROJECT_ID']
-        self._spider = os.environ['SCRAPY_SPIDER']
+        self._projectid = os.environ.get('SCRAPY_PROJECT_ID')
+        self._spider = os.environ.get('SCRAPY_SPIDER')
         self._localpath = os.environ.get(
             'DOTSCRAPY_DIR', os.path.join(os.getcwd(), '.scrapy/'))
         self._env = {

--- a/scrapy_dotpersistence.py
+++ b/scrapy_dotpersistence.py
@@ -26,9 +26,9 @@ class DotScrapyPersistence(object):
         self.AWS_SECRET_ACCESS_KEY = crawler.settings.get(
             'ADDONS_AWS_SECRET_ACCESS_KEY')
         self._bucket = bucket
-        self._bucket_folder = crawler.settings.get('ADDONS_AWS_USERNAME', '')
+        self._aws_username = crawler.settings.get('ADDONS_AWS_USERNAME')
         self._projectid = os.environ.get('SCRAPY_PROJECT_ID')
-        self._spider = os.environ.get('SCRAPY_SPIDER')
+        self._spider = os.environ.get('SCRAPY_SPIDER', 'test_spider')
         self._localpath = os.environ.get(
             'DOTSCRAPY_DIR', os.path.join(os.getcwd(), '.scrapy/'))
         self._env = {
@@ -42,14 +42,10 @@ class DotScrapyPersistence(object):
 
     @property
     def _s3path(self):
-        if self._bucket_folder:
-            return 's3://{0}/{1}/{2}/dot-scrapy/{3}/'.format(
-                self._bucket, self._bucket_folder, self._projectid,
-                self._spider
-            )
-        else:
-            return 's3://{0}/{1}/dot-scrapy/{2}/'.format(
-                self._bucket, self._projectid, self._spider)
+        path = "/".join(
+            filter(None, [self._bucket, self._aws_username, self._projectid])
+        )
+        return "s3://{0}/dot-scrapy/{1}/".format(path, self._spider)
 
     def _load_data(self):
         logger.info('Syncing .scrapy directory from %s' % self._s3path)

--- a/scrapy_dotpersistence.py
+++ b/scrapy_dotpersistence.py
@@ -28,7 +28,7 @@ class DotScrapyPersistence(object):
         self._bucket = bucket
         self._aws_username = crawler.settings.get('ADDONS_AWS_USERNAME')
         self._projectid = os.environ.get('SCRAPY_PROJECT_ID')
-        self._spider = os.environ.get('SCRAPY_SPIDER', 'test_spider')
+        self._spider = os.environ.get('SCRAPY_SPIDER', crawler.spider.name)
         self._localpath = os.environ.get(
             'DOTSCRAPY_DIR', os.path.join(os.getcwd(), '.scrapy/'))
         self._env = {

--- a/scrapy_dotpersistence.py
+++ b/scrapy_dotpersistence.py
@@ -40,16 +40,18 @@ class DotScrapyPersistence(object):
         self._load_data()
         crawler.signals.connect(self._store_data, signals.engine_stopped)
 
-    def _load_data(self):
+    @property
+    def _s3path(self):
         if self._bucket_folder:
-            self._s3path = 's3://{0}/{1}/{2}/dot-scrapy/{3}/'.format(
+            return 's3://{0}/{1}/{2}/dot-scrapy/{3}/'.format(
                 self._bucket, self._bucket_folder, self._projectid,
                 self._spider
             )
         else:
-            self._s3path = 's3://{0}/{1}/dot-scrapy/{2}/'.format(
-                self._bucket, self._projectid, self._spider
-            )
+            return 's3://{0}/{1}/dot-scrapy/{2}/'.format(
+                self._bucket, self._projectid, self._spider)
+
+    def _load_data(self):
         logger.info('Syncing .scrapy directory from %s' % self._s3path)
         cmd = ['aws', 's3', 'sync', self._s3path, self._localpath]
         self._call(cmd)

--- a/scrapy_dotpersistence.py
+++ b/scrapy_dotpersistence.py
@@ -17,7 +17,11 @@ class DotScrapyPersistence(object):
                    settings.get('DOTSCRAPYPERSISTENCE_ENABLED'))
         if not enabled:
             raise NotConfigured
+
         bucket = settings.get('ADDONS_S3_BUCKET')
+        if bucket is None:
+            raise NotConfigured("ADDONS_S3_BUCKET is required")
+
         return cls(crawler, bucket)
 
     def __init__(self, crawler, bucket):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+import pytest
+from scrapy.utils.test import get_crawler
+
+
+@pytest.fixture
+def get_test_crawler():
+    def _crawler(settings_dict={}):
+        crawler = get_crawler(settings_dict=settings_dict)
+        crawler.spider = crawler._create_spider("test_spider")
+        return crawler
+
+    return _crawler

--- a/tests/test_dotpersistence.py
+++ b/tests/test_dotpersistence.py
@@ -112,6 +112,11 @@ class DotScrapyPersisitenceTestCase(TestCase):
 
     def tearDown(self):
         self.patch.stop()
+        del os.environ['SCRAPY_JOB']
+        del os.environ['SCRAPY_PROJECT_ID']
+        del os.environ['SCRAPY_SPIDER']
+        del os.environ['HOME']
+        del os.environ['DOTSCRAPY_DIR']
 
 
 @pytest.mark.parametrize(

--- a/tests/test_dotpersistence.py
+++ b/tests/test_dotpersistence.py
@@ -5,7 +5,6 @@ import mock
 import pytest
 from scrapy.exceptions import NotConfigured
 from scrapy.settings import Settings
-from scrapy.utils.test import get_crawler
 
 from scrapy_dotpersistence import DotScrapyPersistence
 
@@ -122,8 +121,8 @@ class DotScrapyPersisitenceTestCase(TestCase):
 @pytest.mark.parametrize(
     "setting_name", ["DOTSCRAPY_ENABLED", "DOTSCRAPYPERSISTENCE_ENABLED"]
 )
-def test_extension_not_enabled(setting_name):
-    crawler = get_crawler(settings_dict={setting_name: False})
+def test_extension_not_enabled(setting_name, get_test_crawler):
+    crawler = get_test_crawler(settings_dict={setting_name: False})
     with pytest.raises(NotConfigured) as excinfo:
         extension = DotScrapyPersistence.from_crawler(crawler)
 
@@ -131,21 +130,23 @@ def test_extension_not_enabled(setting_name):
 @pytest.mark.parametrize(
     "setting_name", ["DOTSCRAPY_ENABLED", "DOTSCRAPYPERSISTENCE_ENABLED"]
 )
-def test_extension_enabled(setting_name, mocker):
+def test_extension_enabled(setting_name, mocker, get_test_crawler):
     mocker.patch.object(DotScrapyPersistence, "_load_data", autospec=True)
 
-    crawler = get_crawler(settings_dict={setting_name: True})
+    crawler = get_test_crawler(settings_dict={setting_name: True})
     try:
         extension = DotScrapyPersistence.from_crawler(crawler)
     except NotConfigured as excinfo:
         pytest.fail(excinfo)
 
 
-def test_s3path_in_scrapy_cloud_without_aws_username(mocker, monkeypatch):
+def test_s3path_in_scrapy_cloud_without_aws_username(
+    mocker, monkeypatch, get_test_crawler
+):
     mocker.patch.object(DotScrapyPersistence, "_load_data", autospec=True)
     monkeypatch.setenv("SCRAPY_PROJECT_ID", "123")
     monkeypatch.setenv("SCRAPY_SPIDER", "test_spider")
-    crawler = get_crawler(
+    crawler = get_test_crawler(
         settings_dict={"DOTSCRAPY_ENABLED": True, "ADDONS_S3_BUCKET": "s3_bucket"}
     )
     extension = DotScrapyPersistence.from_crawler(crawler)
@@ -153,11 +154,13 @@ def test_s3path_in_scrapy_cloud_without_aws_username(mocker, monkeypatch):
     assert extension._s3path == "s3://s3_bucket/123/dot-scrapy/test_spider/"
 
 
-def test_s3path_in_scrapy_cloud_with_aws_username(mocker, monkeypatch):
+def test_s3path_in_scrapy_cloud_with_aws_username(
+    mocker, monkeypatch, get_test_crawler
+):
     mocker.patch.object(DotScrapyPersistence, "_load_data", autospec=True)
     monkeypatch.setenv("SCRAPY_PROJECT_ID", "123")
     monkeypatch.setenv("SCRAPY_SPIDER", "test_spider")
-    crawler = get_crawler(
+    crawler = get_test_crawler(
         settings_dict={
             "DOTSCRAPY_ENABLED": True,
             "ADDONS_S3_BUCKET": "s3_bucket",
@@ -169,24 +172,21 @@ def test_s3path_in_scrapy_cloud_with_aws_username(mocker, monkeypatch):
     assert extension._s3path == "s3://s3_bucket/username/123/dot-scrapy/test_spider/"
 
 
-def test_s3path_running_locally_without_aws_username(mocker):
+def test_s3path_running_locally_without_aws_username(mocker, get_test_crawler):
     mocker.patch.object(DotScrapyPersistence, "_load_data", autospec=True)
 
-    crawler = get_crawler(
-        settings_dict={
-            "DOTSCRAPY_ENABLED": True,
-            "ADDONS_S3_BUCKET": "s3_bucket",
-        }
+    crawler = get_test_crawler(
+        settings_dict={"DOTSCRAPY_ENABLED": True, "ADDONS_S3_BUCKET": "s3_bucket"}
     )
     extension = DotScrapyPersistence.from_crawler(crawler)
 
     assert extension._s3path == "s3://s3_bucket/dot-scrapy/test_spider/"
 
 
-def test_s3path_running_locally_with_aws_username(mocker):
+def test_s3path_running_locally_with_aws_username(mocker, get_test_crawler):
     mocker.patch.object(DotScrapyPersistence, "_load_data", autospec=True)
 
-    crawler = get_crawler(
+    crawler = get_test_crawler(
         settings_dict={
             "DOTSCRAPY_ENABLED": True,
             "ADDONS_S3_BUCKET": "s3_bucket",

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ deps =
     -rrequirements.txt
     pytest
     pytest-cov
+    pytest-mock
     mock
 commands =
     py.test --cov=scrapy_dotpersistence --cov-report=


### PR DESCRIPTION
The dependence on `SCRAPY_JOB`, `SCRAPY_PROJECT_ID` and `SCRAPY_SPIDER` environment variables prevented the extension to work in an environment different from Scrapy Cloud.

This PR makes it possible to use this extension without requiring the spider to be executed in SCrapy Cloud.