### PR TITLE
Removed reference to non-existent attribute

### DIFF
--- a/scrapy_dotpersistence.py
+++ b/scrapy_dotpersistence.py
@@ -39,7 +39,7 @@ class DotScrapyPersistence(object):
 
         self._aws_username = crawler.settings.get('ADDONS_AWS_USERNAME')
         self._projectid = os.environ.get('SCRAPY_PROJECT_ID')
-        self._spider = os.environ.get('SCRAPY_SPIDER', crawler.spider.name)
+        self._spider = os.environ.get('SCRAPY_SPIDER', "all_spiders")
         self._localpath = os.environ.get(
             'DOTSCRAPY_DIR', os.path.join(os.getcwd(), '.scrapy/'))
         self._env = {


### PR DESCRIPTION
`crawler.spider.name` does not exist in the latest version of scrapy. This has been replaced with a generic `"all_spiders"` if the `SCRAPY_SPIDER` setting is not set.